### PR TITLE
Add preset for the Mercury MTTR01

### DIFF
--- a/source/dlGlobal.pas
+++ b/source/dlGlobal.pas
@@ -117,6 +117,16 @@ type
 
 
 var
+  MTTR01Presets: TDevicePresets = (
+    BaudRate: 2400;
+    DataBits: 8;
+    StopBits: 1.0;
+    Parity: 'N';
+    Handshake: hNone;
+    ReadOut: roAsciiDigits;
+    Digits: 4;
+    Editable: eNone;
+  );
   VC630Presets: TDevicePresets = (
     BaudRate: 4800;
     DataBits: 7;

--- a/source/dlMain.pas
+++ b/source/dlMain.pas
@@ -958,7 +958,7 @@ procedure TMainForm.FormCloseQuery(Sender:TObject; var CanClose:boolean);
 var
   res: Integer;
 begin
-  res := MessageDlg('Do your really want to close this program?',
+  res := MessageDlg('Do you really want to close this program?',
     mtConfirmation, [mbYes, mbNo], 0);
   CanClose := (res = mrYes);
 

--- a/source/dlSerialPortSettings.pas
+++ b/source/dlSerialPortSettings.pas
@@ -184,6 +184,7 @@ begin
     AddDefault('Conrad VC830', VC830_850Presets);
     AddDefault('Conrad VC840', VC820_840Presets);
     AddDefault('Conrad VC850', VC830_850Presets);
+    AddDefault('Mercury MTTR01', MTTR01Presets);
 
     for i:=0 to List.Count-1 do begin
       s := ini.ReadString(Section, List[i], '');
@@ -315,6 +316,7 @@ begin
     FPresets.AddDefault('Conrad VC830', VC830_850Presets);
     FPresets.AddDefault('Conrad VC840', VC820_840Presets);
     FPresets.AddDefault('Conrad VC850', VC830_850Presets);
+    FPresets.AddDefault('Mercury MTTR01', MTTR01Presets);
     FPresets.AddDefault('user-defined', OtherPresets);
   end;
 


### PR DESCRIPTION
Adds support in the presets list for the Mercury MTTR01 Multimeter (A moderately common cheap meter in the UK)
https://www.avsl.com/assets/manuals/6/0/600104UK.pdf

Also corrected a very minor typo.